### PR TITLE
chore: enforce formatting rules in PR description bot

### DIFF
--- a/.github/workflows/pr-description-bot.yml
+++ b/.github/workflows/pr-description-bot.yml
@@ -100,6 +100,8 @@ jobs:
               'Rules:',
               '- Do not add any extra top-level sections.',
               '- Never wrap the response in code fences (no ```markdown).',
+              '- For the first three sections, use bullet points only (`- `). Do not use paragraphs.',
+              '- For the "How to test/verify?" section, use numbered steps only (`1.`, `2.`, ...).',
               '- Keep it concrete and specific to the actual code changes.',
               '- Keep the writing concise and professional.',
               '- If dependency impact is minimal, explicitly say so in the dependency graph section.',
@@ -160,6 +162,49 @@ jobs:
             const missingHeadings = requiredHeadings.filter((heading) => !cleaned.includes(heading));
             if (missingHeadings.length > 0) {
               core.setFailed(`Generated description missing required headings: ${missingHeadings.join(', ')}`);
+              return;
+            }
+
+            const getSectionBody = (markdown, heading, nextHeading) => {
+              const start = markdown.indexOf(heading);
+              if (start < 0) return '';
+              const sectionStart = start + heading.length;
+              const end = nextHeading ? markdown.indexOf(nextHeading, sectionStart) : markdown.length;
+              return markdown.slice(sectionStart, end < 0 ? markdown.length : end).trim();
+            };
+
+            const firstSectionBody = getSectionBody(cleaned, requiredHeadings[0], requiredHeadings[1]);
+            const secondSectionBody = getSectionBody(cleaned, requiredHeadings[1], requiredHeadings[2]);
+            const thirdSectionBody = getSectionBody(cleaned, requiredHeadings[2], requiredHeadings[3]);
+            const testSectionBody = getSectionBody(cleaned, requiredHeadings[3], null);
+
+            const hasBulletOnly = (text) => {
+              const lines = text
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean);
+              return lines.length > 0 && lines.every((line) => line.startsWith('- '));
+            };
+
+            const hasNumberedStepsOnly = (text) => {
+              const lines = text
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean);
+              return lines.length > 0 && lines.every((line) => /^\d+\.\s+/.test(line));
+            };
+
+            const bulletViolations = [];
+            if (!hasBulletOnly(firstSectionBody)) bulletViolations.push(requiredHeadings[0]);
+            if (!hasBulletOnly(secondSectionBody)) bulletViolations.push(requiredHeadings[1]);
+            if (!hasBulletOnly(thirdSectionBody)) bulletViolations.push(requiredHeadings[2]);
+            if (bulletViolations.length > 0) {
+              core.setFailed(`Generated description must use bullet points only in: ${bulletViolations.join(', ')}`);
+              return;
+            }
+
+            if (!hasNumberedStepsOnly(testSectionBody)) {
+              core.setFailed(`Generated description must use numbered steps only in: ${requiredHeadings[3]}`);
               return;
             }
 


### PR DESCRIPTION
## What does this PR do?
- Adds new formatting rules to the PR description bot.
- Enforces that the first three sections (`What does this PR do?`, `Why did you choose this solution?`, `What is the dependency graph of the changes?`) must use bullet points only.
- Enforces that the "How to test/verify?" section must use numbered steps only.
- Implements JavaScript logic within the `pr-description-bot.yml` workflow to validate these new formatting constraints.

## Why did you choose this solution?
- To standardize the structure and readability of PR descriptions.
- To improve consistency across all pull requests by ensuring specific formatting for different sections.
- To leverage the existing PR description bot workflow for automated validation, preventing non-compliant descriptions from being merged.

## What is the dependency graph of the changes?
- This change modifies an existing GitHub Actions workflow file (`.github/workflows/pr-description-bot.yml`).
- It introduces new validation logic within the workflow's JavaScript, which depends on the `github` and `core` contexts provided by GitHub Actions.
- Dependency impact is minimal as it only affects the PR description validation process and does not alter any application code or external services.

## How to test/verify?
1. Create a new pull request with a description that violates the new formatting rules (e.g., using paragraphs in the first three sections or bullet points in the "How to test/verify?" section).
2. Observe that the `pr-description-bot` workflow fails with a specific error message indicating the formatting violation.
3. Update the pull request description to comply with the new rules (bullet points for the first three sections, numbered steps for the last).
4. Observe that the `pr-description-bot` workflow passes successfully.
5. Verify that a PR description with correct formatting also passes the bot.