### PR TITLE
docs: add comprehensive guide on navigation in React Native, fixes #108

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
     "inclusivity",
     "incase",
     "timeboxed",
+    "myapp",
     "blocklisting",
     "Tiimo",
     "Routinery",

--- a/milestones/milestone-8-react-native-fundamentals/rn-navigation.md
+++ b/milestones/milestone-8-react-native-fundamentals/rn-navigation.md
@@ -1,0 +1,23 @@
+# Navigation in React Native using React Navigation
+
+## Reflections
+
+### What are the key differences between stack, tab, and drawer navigation
+
+Stack is like pages on top of each other: you “push” screens and go back through history. Tabs are your main sections
+that stay visible so users can jump around fast (Dashboard, Bookings, Settings). Drawer is a hidden side menu for extra
+sections that don’t need to be front-and-center, usually opened with a swipe or hamburger icon.
+
+### How does React Navigation handle screen transitions
+
+When you navigate, it updates an internal navigation state (which route is active, what’s in the stack) then renders
+the new screen. The transition animation comes from the navigator type (stack does slide/push by default, tabs
+typically switch, drawer slides in) and can be customized per screen. Under the hood it’s basically
+“dispatch an action → router calculates next state → navigator animates to that state.”
+
+### How would you implement deep linking in a React Native app
+
+With Expo Router, deep linking is mostly file-based, meaning your folder structure already defines the URL paths. You
+configure an app scheme in `app.json`, and links like `myapp://customers/123` automatically map
+to `app/customers/[id].tsx`. Inside that screen, you use `useLocalSearchParams()` to access the dynamic
+values from the link.


### PR DESCRIPTION
## What does this PR do?
- Adds a new documentation file `rn-navigation.md` providing a comprehensive guide on navigation in React Native using React Navigation.
- Explains the key differences between stack, tab, and drawer navigation.
- Describes how React Navigation handles screen transitions.
- Details the implementation of deep linking, specifically with Expo Router.
- Adds "myapp" to the `cspell.json` dictionary to prevent linting errors in the new document.

## Why did you choose this solution?
- To address the need for a comprehensive guide on React Native navigation, as indicated by the PR title and the fix for #108.
- The content directly answers common questions and concepts related to navigation, providing foundational knowledge.
- Using a new Markdown file keeps the documentation organized and easily discoverable within the `milestones` structure.
- Adding "myapp" to `cspell.json` ensures consistency and avoids false positives for a common placeholder term used in the documentation.

## What is the dependency graph of the changes?
- The new documentation file `rn-navigation.md` is self-contained and does not introduce new code dependencies.
- The `cspell.json` modification is a configuration change for linting and does not affect runtime dependencies.
- Dependency impact is minimal.

## How to test/verify?
1. Navigate to the `milestones/milestone-8-react-native-fundamentals/` directory in the repository.
2. Open the `rn-navigation.md` file.
3. Verify that the content accurately describes stack, tab, and drawer navigation, screen transitions, and deep linking with Expo Router.
4. Check for any typos or grammatical errors in the new document.
5. Run the project's spell-checking command (e.g., `npm run lint` if configured) to ensure no new spell-check warnings are introduced, specifically verifying that "myapp" is not flagged.