### PR TITLE
feat: implement local Expo Module demo and react-native-config, fixes #102

### DIFF
--- a/milestones/milestone-12-focus-bear-libraries/rn-native-modules.md
+++ b/milestones/milestone-12-focus-bear-libraries/rn-native-modules.md
@@ -1,0 +1,72 @@
+# Onboarding Task - Using Native Modules and Bridging in React Native
+
+## Trying out config and native modules in the Milestone-8 app
+
+Inside `milestone-8-react-native-fundamentals/react-native-app`, I explored two related topics:
+configuration handling and custom native modules.
+
+For configuration, I checked whether `react-native-config` was already being used or whether it should be added. The
+app was already using Expo-style environment variables through `process.env.EXPO_PUBLIC_SENTRY_DSN`, backed by `.env`
+and `.env.example`. Because this project is still Expo-managed and does not have committed `ios/` or `android/`
+folders, I kept the Expo approach and documented that `react-native-config` would only make sense later in a prebuilt
+or bare workflow where native build-time injection is actually needed.
+
+For native modules, I added a small local Expo Module demo under `modules/native-demo-module`. It exposes a single
+cross-platform function called `getNativeDemoInfo()` that returns a simple object with a `platform` and `message`.
+The sandbox tab in the milestone-8 app now includes a "Run Native Module Demo" button that calls the module from
+JavaScript and shows the returned native response when it is available.
+
+## Proof of trying it out
+
+The config proof is visible in the milestone-8 app setup:
+
+- `lib/sentry.ts` reads `EXPO_PUBLIC_SENTRY_DSN`
+- `.env.example` includes the Sentry DSN key
+- `README.md` now explains why Expo env handling is the right fit instead of `react-native-config`
+
+The native module proof is visible in the local Expo Module integration:
+
+- `modules/native-demo-module/android/.../NativeDemoModule.kt` returns an Android-specific response
+- `modules/native-demo-module/ios/NativeDemoModule.swift` returns an iOS-specific response
+- `lib/native-demo.ts` provides the typed JavaScript wrapper
+- `app/(tabs)/sandbox.tsx` calls the module and displays loading, success, and fallback states
+
+I also verified the setup with checks that passed locally:
+
+- `npm run lint`
+- `npx tsc --noEmit`
+- `npx expo-modules-autolinking search --platform android`
+
+The autolinking check found `native-demo-module`, which confirms Expo can discover the custom module. The runtime test
+behavior is that a development build should show the platform-specific response, while Expo Go will show the fallback
+message because it does not include custom native code compiled into its binary.
+
+## Reflection
+
+### Why would you need to use native modules in a React Native app
+
+You need native modules when JavaScript alone cannot access a device capability or platform API that your app
+requires. Examples include integrating a platform-specific SDK, exposing custom device functionality, using a native
+library that has no good JavaScript-only alternative, or optimizing performance-sensitive work that is better handled
+closer to the platform layer. In an Expo app, this decision usually comes after checking whether an Expo SDK package
+or config plugin already solves the problem. Native modules are most useful when the feature is genuinely custom and
+cannot be handled well by existing cross-platform abstractions.
+
+### How does React Native communicate with native code
+
+React Native communicates with native code by exposing native functionality as modules that JavaScript can call. In
+older bridge-based designs, data moved back and forth asynchronously across the React Native bridge. In newer systems,
+including Expo Modules and the newer React Native architecture, this communication can be more direct and structured,
+with native methods registered under a module name and then accessed from JavaScript through typed wrappers. In this
+milestone app, the JavaScript side calls `getNativeDemoInfo()`, and the Android or iOS implementation returns a plain
+object that React Native can pass back to the JavaScript runtime.
+
+### What are some challenges of maintaining native bridges
+
+Maintaining native bridges adds complexity because the feature has to stay consistent across JavaScript, Android, and
+iOS at the same time. A change in the data contract or method signature needs to be reflected in multiple languages
+and build systems, which increases the risk of drift. Teams also need to manage platform differences, native build
+errors, dependency upgrades, autolinking issues, and testing in environments where custom modules may not exist, such
+as Expo Go. Another challenge is that debugging becomes more involved because failures can come from JavaScript, the
+bridge layer, or the native implementation itself. That is why it is usually best to use native modules only when the
+extra power is worth the additional maintenance cost.

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/README.md
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/README.md
@@ -27,6 +27,42 @@ In the output, you'll find options to open the app in a
 You can start developing by editing the files inside the **app** directory.
 This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
+## Environment variables
+
+This milestone app already uses Expo environment variables instead of `react-native-config`.
+
+1. Copy `.env.example` to `.env`.
+2. Set `EXPO_PUBLIC_SENTRY_DSN` if you want to test Sentry from the sandbox tab.
+3. Restart Expo after changing env values so Metro picks them up.
+
+`react-native-config` is usually not the right fit for this project in its current state because this app is still an
+Expo-managed app without committed native `ios/` and `android/` folders. If you later switch to a prebuilt or fully
+bare React Native workflow and need native build-time env injection, that is the point where adding
+`react-native-config` would make sense.
+
+## Local Expo Module demo
+
+This app now includes a small local Expo Module in `modules/native-demo-module` to demonstrate the
+recommended way to add custom native code in an Expo-managed project.
+
+Use this decision rule:
+
+1. Prefer Expo SDK packages when a built-in capability already exists.
+2. Use a config plugin when a library needs native project configuration.
+3. Use an Expo Module when you need custom native behavior that Expo does not already provide.
+
+The sandbox tab includes a "Run Native Module Demo" button that calls `getNativeDemoInfo()` from
+native Android or iOS code.
+
+To verify the module:
+
+1. Start with `npx expo start`.
+2. Build and open a development client for Android or iOS.
+3. Open the sandbox tab and run the native module demo.
+
+Expo Go may show the module as unavailable because local custom native modules are expected to run
+in a development build.
+
 ## Get a fresh project
 
 When you're ready, run:

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/app/(tabs)/sandbox.tsx
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/app/(tabs)/sandbox.tsx
@@ -21,6 +21,11 @@ import Animated, {
 import { AppHeader } from '@/components/app-header';
 import { BrandBackground } from '@/components/brand-background';
 import { BrandColors, BrandFonts } from '@/constants/brand-theme';
+import {
+  getNativeDemoInfo,
+  isNativeDemoModuleAvailable,
+  type NativeDemoInfo,
+} from '@/lib/native-demo';
 import { captureSandboxError, isSentryEnabled } from '@/lib/sentry';
 
 export default function SandboxScreen() {
@@ -35,6 +40,13 @@ export default function SandboxScreen() {
   const [swipeStatus, setSwipeStatus] = useState('Swipe left or right');
   const [longPressStatus, setLongPressStatus] = useState('Press and hold');
   const [interactionStatus, setInteractionStatus] = useState('Scheduling deferred task...');
+  const [nativeModuleStatus, setNativeModuleStatus] = useState(
+    isNativeDemoModuleAvailable()
+      ? 'Ready to call the local Expo Module from JavaScript.'
+      : 'Local Expo Module not loaded. Use a development build instead of Expo Go to test it.'
+  );
+  const [nativeModuleResult, setNativeModuleResult] = useState<NativeDemoInfo | null>(null);
+  const [isRunningNativeModule, setIsRunningNativeModule] = useState(false);
   const [sentryStatus, setSentryStatus] = useState(
     isSentryEnabled
       ? 'Ready to send a test event to Sentry.'
@@ -111,6 +123,23 @@ export default function SandboxScreen() {
     setSentryStatus(`Captured test error: "${errorMessage}"`);
   };
 
+  const handleRunNativeModuleDemo = async () => {
+    setIsRunningNativeModule(true);
+    setNativeModuleResult(null);
+    setNativeModuleStatus('Calling native code...');
+
+    try {
+      const result = await getNativeDemoInfo();
+      setNativeModuleResult(result);
+      setNativeModuleStatus(`Native module responded from ${result.platform}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown native module error';
+      setNativeModuleStatus(message);
+    } finally {
+      setIsRunningNativeModule(false);
+    }
+  };
+
   return (
     <View style={styles.screen}>
       <BrandBackground />
@@ -157,6 +186,36 @@ export default function SandboxScreen() {
           <Text style={styles.demoBody}>
             Use this to delay expensive JS work until active interactions and animations finish.
           </Text>
+        </View>
+
+        <View style={[styles.block, { padding: cardPadding }]}>
+          <Text style={styles.label}>Expo Modules API</Text>
+          <Text style={[styles.sectionTitle, { fontSize: titleSize }]}>Custom Native Module</Text>
+          <Text style={[styles.statusText, { fontSize: bodySize }]}>{nativeModuleStatus}</Text>
+          <Text style={styles.demoBody}>
+            This demo calls a local Expo Module. It works in a development build and gracefully
+            falls back when the native module is unavailable.
+          </Text>
+          {nativeModuleResult ? (
+            <View style={styles.resultCard}>
+              <Text style={styles.demoTitle}>Native Response</Text>
+              <Text style={styles.demoBody}>Platform: {nativeModuleResult.platform}</Text>
+              <Text style={styles.demoBody}>Message: {nativeModuleResult.message}</Text>
+            </View>
+          ) : null}
+          <Pressable
+            accessibilityRole="button"
+            disabled={isRunningNativeModule}
+            onPress={handleRunNativeModuleDemo}
+            style={({ pressed }) => [
+              styles.sentryButton,
+              pressed ? styles.sentryButtonPressed : null,
+              isRunningNativeModule ? styles.sentryButtonDisabled : null,
+            ]}>
+            <Text style={styles.sentryButtonText}>
+              {isRunningNativeModule ? 'Calling Native Module...' : 'Run Native Module Demo'}
+            </Text>
+          </Pressable>
         </View>
 
         <View style={[styles.block, { padding: cardPadding }]}>
@@ -245,6 +304,15 @@ const styles = StyleSheet.create({
     backgroundColor: BrandColors.accent,
     marginTop: 2,
     marginBottom: 4,
+  },
+  resultCard: {
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: 'rgba(30,38,22,0.62)',
+    borderWidth: 1,
+    borderColor: 'rgba(138,154,91,0.25)',
+    gap: 4,
   },
   sentryButton: {
     marginTop: 6,

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/env.ts
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/env.ts
@@ -1,0 +1,5 @@
+const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN?.trim();
+
+export const env = {
+  sentryDsn: sentryDsn || undefined,
+};

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/native-demo.ts
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/native-demo.ts
@@ -1,0 +1,23 @@
+import NativeDemoModule, { type NativeDemoInfo } from '@/modules/native-demo-module';
+
+const unavailableMessage =
+  'Native demo module is unavailable in this runtime. Build a development client to test local Expo Modules.';
+
+export { type NativeDemoInfo };
+
+export function isNativeDemoModuleAvailable() {
+  return Boolean(NativeDemoModule);
+}
+
+export async function getNativeDemoInfo(): Promise<NativeDemoInfo> {
+  if (!NativeDemoModule) {
+    throw new Error(unavailableMessage);
+  }
+
+  try {
+    return await NativeDemoModule.getNativeDemoInfo();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown native module error';
+    throw new Error(`Native demo module failed: ${message}`);
+  }
+}

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/sentry.ts
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/lib/sentry.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native';
+import { env } from '@/lib/env';
 
-const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+const sentryDsn = env.sentryDsn;
 
 export const isSentryEnabled = Boolean(sentryDsn);
 

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/build.gradle
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.nativedemomodule'
+version = '1.0.0'
+
+android {
+  namespace "expo.modules.nativedemomodule"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+}

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/src/main/AndroidManifest.xml
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/src/main/java/expo/modules/nativedemomodule/NativeDemoModule.kt
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/android/src/main/java/expo/modules/nativedemomodule/NativeDemoModule.kt
@@ -1,0 +1,17 @@
+package expo.modules.nativedemomodule
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class NativeDemoModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("NativeDemoModule")
+
+    AsyncFunction("getNativeDemoInfo") {
+      mapOf(
+        "platform" to "android",
+        "message" to "Hello from the Android Expo Module demo."
+      )
+    }
+  }
+}

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/expo-module.config.json
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["NativeDemoModule"],
+    "podspecPath": "ios/NativeDemoModule.podspec"
+  },
+  "android": {
+    "modules": ["expo.modules.nativedemomodule.NativeDemoModule"]
+  }
+}

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/index.ts
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/index.ts
@@ -1,0 +1,12 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+export type NativeDemoInfo = {
+  platform: string;
+  message: string;
+};
+
+type NativeDemoModuleType = {
+  getNativeDemoInfo(): Promise<NativeDemoInfo>;
+};
+
+export default requireOptionalNativeModule<NativeDemoModuleType>('NativeDemoModule');

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/ios/NativeDemoModule.podspec
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/ios/NativeDemoModule.podspec
@@ -1,0 +1,40 @@
+require 'json'
+
+absolute_react_native_path = ''
+if !ENV['REACT_NATIVE_PATH'].nil?
+  absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+else
+  absolute_react_native_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`).strip
+end
+
+unless defined?(install_modules_dependencies)
+  require File.join(absolute_react_native_path, 'scripts/react_native_pods')
+end
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'NativeDemoModule'
+  s.version = package['version']
+  s.summary = 'Local Expo Module demo for milestone-8'
+  s.description = 'A small Expo Module used to demonstrate custom native integration.'
+  s.license = 'MIT'
+  s.author = 'OpenAI Codex'
+  s.homepage = 'https://expo.dev'
+  s.platforms = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.swift_version = '5.9'
+  s.source = { git: 'https://example.com/native-demo-module.git', tag: s.version.to_s }
+  s.static_framework = true
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = 'ios/**/*.{h,m,mm,swift}'
+
+  install_modules_dependencies(s)
+end

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/ios/NativeDemoModule.swift
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/ios/NativeDemoModule.swift
@@ -1,0 +1,14 @@
+import ExpoModulesCore
+
+public final class NativeDemoModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("NativeDemoModule")
+
+    AsyncFunction("getNativeDemoInfo") {
+      [
+        "platform": "ios",
+        "message": "Hello from the iOS Expo Module demo."
+      ]
+    }
+  }
+}

--- a/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/package.json
+++ b/milestones/milestone-8-react-native-fundamentals/react-native-app/modules/native-demo-module/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "native-demo-module",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "private": true,
+  "peerDependencies": {
+    "expo": "*",
+    "expo-modules-core": "*",
+    "react-native": "*"
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Implements a local Expo Module demo named `native-demo-module` within the `milestone-8-react-native-fundamentals` app.
- The module exposes a cross-platform `getNativeDemoInfo()` function that returns platform-specific information (e.g., Android or iOS).
- Integrates the native module into the app's sandbox tab, allowing users to trigger the native call and display its response.
- Adds documentation (`rn-native-modules.md`) detailing the implementation of the local Expo Module and the evaluation of `react-native-config`.
- Updates the `README.md` of the `milestone-8-react-native-fundamentals` app with instructions for environment variables and the native module demo.
- Refactors Sentry DSN configuration to use a new `lib/env.ts` file for centralized environment variable access.

## Why did you choose this solution?
- To demonstrate the recommended approach for adding custom native code in an Expo-managed project using local Expo Modules.
- To provide a concrete example of bridging JavaScript and native code (Kotlin for Android, Swift for iOS) within the existing app structure.
- To clarify the appropriate use of environment variable handling in an Expo-managed app, opting for Expo's built-in `process.env.EXPO_PUBLIC_` variables over `react-native-config` due to the project's current workflow.
- To fulfill the requirements of issue #102 by exploring and implementing native module capabilities.

## What is the dependency graph of the changes?
- The new `native-demo-module` is a local dependency of the `milestone-8-react-native-fundamentals` app.
- The `sandbox.tsx` component now depends on `lib/native-demo.ts`, which in turn depends on the `native-demo-module`.
- `lib/sentry.ts` now depends on the newly added `lib/env.ts` for environment variable access.
- The changes introduce new files for the native module (Kotlin, Swift, config, JS wrapper) and update existing JavaScript/TypeScript files.
- Overall dependency impact is minimal as it introduces a new self-contained module and refactors an existing environment variable access pattern.

## How to test/verify?
1. Ensure you have a `.env` file in `milestone-8-react-native-fundamentals/react-native-app` (copy from `.env.example`).
2. Navigate to `milestone-8-react-native-fundamentals/react-native-app`.
3. Run `npm install` to ensure all dependencies, including the local module, are linked.
4. Start the Expo development server with `npx expo start`.
5. Build and open a development client for Android or iOS (e.g., `npx expo run:android` or `npx expo run:ios`).
6. Open the app on the development client.
7. Navigate to the "Sandbox" tab.
8. Locate the "Custom Native Module" section and tap the "Run Native Module Demo" button.
9. Verify that the status updates to "Calling native code..." and then displays a platform-specific response (e.g., "Native module responded from Android." or "Native module responded from iOS.").
10. (Optional) Test the Sentry integration by setting `EXPO_PUBLIC_SENTRY_DSN` in `.env` and triggering a test error from the "Test Error Logging" section.
11. (Optional) Verify that running the app in Expo Go (instead of a development client) shows the fallback message for the native module, indicating it's unavailable.